### PR TITLE
Use $BASH_SOURCE if available to get the location of the file in hadoop-dev-script.sh

### DIFF
--- a/hadoop-dev-scripts.sh
+++ b/hadoop-dev-scripts.sh
@@ -3,7 +3,7 @@
 # Source this file to make all the scripts available on your PATH
 
 # Location of this file
-DIR="$( cd "$( dirname "$0" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE:-$0}" )" && pwd )"
 
 # Set up the PATH relative to the base DIR
 export PATH=$PATH:$DIR/


### PR DESCRIPTION
In my environment (Mac OS X), the script fails by

```
$ source hadoop-dev-script.sh
dirname: illegal option -- b
usage: dirname path
```

This is because if bash calls source and source calls a file, `$0` is set to the shell itself, not to the filename. To fix this, use `$BASH_SOURCE` if available.
